### PR TITLE
feat: blocklist import/export, in-feed subreddit blocking, stats tracking & keyword fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Advanced Reddit Filters
 
-Advanced Reddit Filters is a Chrome extension that enhances your browsing experience on Reddit by allowing you to block specific users, keywords, subreddits, and news domains. With an additional feature to automatically display images linked in comments and posts, Reddit Filters makes your Reddit experience more customizable and visually engaging.
+Advanced Reddit Filters is a Chrome extension that enhances your browsing experience on Reddit by allowing you to block specific users, keywords, subreddits, and websites. With an additional feature to automatically display images linked in comments and posts, Reddit Filters makes your Reddit experience more customizable and visually engaging.
 
 ## Features
 

--- a/popup.css
+++ b/popup.css
@@ -273,3 +273,91 @@ input:checked + .slider.small:before {
   display: flex;
   align-items: center;
 }
+
+.importExportSection {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  padding: 0.5rem 0 0.5rem 0;
+}
+
+.actionButton {
+  padding: 6px 16px;
+  border: none;
+  border-radius: 4px;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.2s, opacity 0.2s;
+}
+
+.exportBtn:hover {
+  background-color: #cc0052;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(255, 0, 102, 0.3);
+}
+
+.importBtn:hover {
+  background-color: #555;
+  transform: translateY(-1px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+.exportBtn {
+  background-color: #ff0066;
+  color: white;
+}
+
+.importBtn {
+  background-color: #333;
+  color: white;
+}
+
+.importExportSection {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  padding: 0.5rem 0 0.5rem 0;
+  position: relative;
+}
+
+.importSuccess {
+  color: #006600;
+  font-size: 12px;
+  font-weight: 700;
+  text-align: center;
+  position: absolute;
+  top: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  opacity: 0;
+}
+
+.importSuccess.visible {
+  animation: successFlash 1.8s ease forwards;
+}
+
+@keyframes successFlash {
+  0% { opacity: 0; }
+  10% { opacity: 1; transform: translateX(-50%) scale(1); }
+  15% { transform: translateX(-50%) scale(1.08); }
+  25% { transform: translateX(-50%) scale(1); }
+  100% { opacity: 1; }
+}
+
+.importSuccess {
+  color: #006600;
+  font-size: 12px;
+  font-weight: bold !important;
+  text-align: center;
+  position: absolute;
+  top: -22px;
+  left: 50%;
+  transform: translateX(-50%);
+  white-space: nowrap;
+  opacity: 0;
+}
+
+.importSuccess.visible {
+  animation: successFlash 1.8s ease forwards;
+}

--- a/popup.css
+++ b/popup.css
@@ -3,10 +3,26 @@ body {
   width: 310px;
   height: 600px;
   background-color: yellow;
+  overflow-y: auto;
 }
 
 html::-webkit-scrollbar {
-  display: none;
+  display: block;
+  width: 8px;
+}
+
+html::-webkit-scrollbar-track {
+  background: rgba(255,255,255,0.3);
+  border-radius: 4px;
+}
+
+html::-webkit-scrollbar-thumb {
+  background: rgba(0,0,0,0.3);
+  border-radius: 4px;
+}
+
+html::-webkit-scrollbar-thumb:hover {
+  background: rgba(0,0,0,0.5);
 }
 
 h1 {
@@ -22,11 +38,77 @@ h3 {
   margin-top: 0rem;
   margin-bottom: 0rem;
 }
+
 .inputList {
   width: 300px;
-  height: 300px;
+  height: 150px;
   white-space: pre-wrap;
   font-family: monospace;
+}
+
+/* Draggable section styles */
+.draggableSection {
+  margin-bottom: 4px;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.3);
+  transition: opacity 0.15s;
+}
+
+.draggableSection.dragging {
+  opacity: 0.4;
+}
+
+body:has(.draggableSection.dragging) {
+  cursor: grabbing !important;
+}
+
+.sectionHeader {
+  display: flex;
+  align-items: center;
+  padding: 4px 8px;
+  cursor: grab;
+  user-select: none;
+  background: rgba(255,255,255,0.1);
+  border-radius: 4px 4px 0 0;
+}
+
+.sectionHeader:hover {
+  cursor: grabbing;
+}
+
+.dragHandle {
+  font-size: 16px;
+  color: rgba(0,0,0,0.4);
+  margin-right: 8px;
+  flex-shrink: 0;
+  line-height: 1;
+  transition: color 0.2s;
+}
+
+.sectionHeader:hover .dragHandle {
+  color: #ff0066;
+}
+
+.sectionContent {
+  padding: 4px 8px 8px 8px;
+}
+
+.nukeHeader {
+  border-radius: 3px;
+}
+
+/* Drop zone indicator at the bottom - shows when dragging */
+.drop-zone {
+  height: 4px;
+  margin: -2px 0 6px 0;
+  background: #ff0066;
+  opacity: 0;
+  transition: opacity 0.15s;
+  pointer-events: auto;
+}
+
+body:has(.draggableSection.dragging) .drop-zone {
+  opacity: 1;
 }
 
 .nukeSection {
@@ -99,7 +181,8 @@ h3 {
   display: inline-block;
   width: 50px;
   height: 22px;
-  margin-left: 1rem;
+  margin-left: auto;
+  flex-shrink: 0;
 }
 
 /* Hide default HTML checkbox */

--- a/popup.css
+++ b/popup.css
@@ -95,6 +95,51 @@ body:has(.draggableSection.dragging) {
 
 .nukeHeader {
   border-radius: 3px;
+  min-height: 34px;
+}
+
+.nukeConfirmLabel {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  color: rgba(0,0,0,0.7);
+  white-space: nowrap;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.nukeConfirmLabel .switch {
+  width: 36px;
+  height: 18px;
+}
+
+.nukeConfirmLabel .slider {
+  width: 36px;
+  height: 18px;
+}
+
+.nukeConfirmLabel .slider:before {
+  height: 12px;
+  width: 12px;
+  left: 3px;
+  bottom: 3px;
+}
+
+.nukeConfirmLabel input:checked + .slider:before {
+  -webkit-transform: translateX(18px);
+  -ms-transform: translateX(18px);
+  transform: translateX(18px);
+}
+
+.nukeHeader .switch {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.nukeTitle {
+  margin: 0;
+  flex-shrink: 1;
 }
 
 /* Drop zone indicator at the bottom - shows when dragging */
@@ -183,6 +228,10 @@ body:has(.draggableSection.dragging) .drop-zone {
   height: 22px;
   margin-left: auto;
   flex-shrink: 0;
+}
+
+.nukeHeader .switch {
+  min-width: 50px;
 }
 
 /* Hide default HTML checkbox */

--- a/popup.css
+++ b/popup.css
@@ -166,9 +166,6 @@ body:has(.draggableSection.dragging) .drop-zone {
   height: auto;
 }
 
-.nukeTitle {
-  margin: 0;
-}
 .buttonWrapper {
   position: relative;
   top: -1rem;
@@ -323,13 +320,6 @@ input:checked + .slider.small:before {
   align-items: center;
 }
 
-.importExportSection {
-  display: flex;
-  gap: 8px;
-  justify-content: center;
-  padding: 0.5rem 0 0.5rem 0;
-}
-
 .actionButton {
   padding: 6px 16px;
   border: none;
@@ -372,7 +362,7 @@ input:checked + .slider.small:before {
 .importSuccess {
   color: #006600;
   font-size: 12px;
-  font-weight: 700;
+  font-weight: bold !important;
   text-align: center;
   position: absolute;
   top: -22px;
@@ -392,21 +382,4 @@ input:checked + .slider.small:before {
   15% { transform: translateX(-50%) scale(1.08); }
   25% { transform: translateX(-50%) scale(1); }
   100% { opacity: 1; }
-}
-
-.importSuccess {
-  color: #006600;
-  font-size: 12px;
-  font-weight: bold !important;
-  text-align: center;
-  position: absolute;
-  top: -22px;
-  left: 50%;
-  transform: translateX(-50%);
-  white-space: nowrap;
-  opacity: 0;
-}
-
-.importSuccess.visible {
-  animation: successFlash 1.8s ease forwards;
 }

--- a/popup.html
+++ b/popup.html
@@ -96,7 +96,7 @@
     <div class="draggableSection" data-section="domains">
       <div class="sectionHeader">
         <span class="dragHandle">&#9776;</span>
-        <h2>Blocked News Domains</h2>
+        <h2>Blocked Websites</h2>
         <label class="switch">
           <input type="checkbox" id="blockDomains" checked />
           <span class="slider round"></span>
@@ -106,7 +106,8 @@
         <textarea
           class="inputList"
           id="domainList"
-          placeholder="Enter each domain on a new line"
+          placeholder="Enter each website or URL on a new line
+(e.g. cnn.com, https://cnn.com)"
         ></textarea>
       </div>
     </div>

--- a/popup.html
+++ b/popup.html
@@ -12,6 +12,13 @@
       <div class="sectionHeader nukeHeader">
         <span class="dragHandle">&#9776;</span>
         <h3 class="nukeTitle">Nuke Current Thread?</h3>
+        <div class="nukeConfirmLabel">
+          Require Confirm
+          <label class="switch nukeConfirmSwitch">
+            <input type="checkbox" id="nukeConfirm" checked />
+            <span class="slider round"></span>
+          </label>
+        </div>
       </div>
       <div class="sectionContent">
         <div class="nukeSection">

--- a/popup.html
+++ b/popup.html
@@ -124,6 +124,15 @@
         </label>
       </div>
     </div>
+
+     <!-- Import/Export -->
+    <div class="importExportSection">
+      <button id="exportBtn" class="actionButton exportBtn">Export</button>
+      <button id="importBtn" class="actionButton importBtn">Import</button>
+      <input type="file" id="importFileInput" accept=".jsonl,.txt" style="display:none" />
+      <div id="importSuccess" class="importSuccess" style="display:none">Successfully imported!</div>
+    </div>
+
     <script src="popup.js"></script>
   </body>
 </html>

--- a/popup.html
+++ b/popup.html
@@ -14,7 +14,7 @@
         <h3 class="nukeTitle">Nuke Current Thread?</h3>
         <div class="nukeConfirmLabel">
           Require Confirm
-          <label class="switch nukeConfirmSwitch">
+          <label class="switch">
             <input type="checkbox" id="nukeConfirm" checked />
             <span class="slider round"></span>
           </label>

--- a/popup.html
+++ b/popup.html
@@ -8,78 +8,105 @@
     <h1>Advanced Reddit Filters</h1>
 
     <!-- Nuke -->
-    <div class="nukeSection">
-      <h3 class="nukeTitle">Nuke Current Thread?</h3>
-      <div class="buttonWrapper">
-        <div class="nukeButton">
-          <a style="color: #ff0066"></a>
-        </div>
-        <div class="nukeButton1"></div>
+    <div class="draggableSection" data-section="nuke">
+      <div class="sectionHeader nukeHeader">
+        <span class="dragHandle">&#9776;</span>
+        <h3 class="nukeTitle">Nuke Current Thread?</h3>
       </div>
-      <p id="nukeDescription">
-        The author and all commentors will be added to your user block list.
-      </p>
+      <div class="sectionContent">
+        <div class="nukeSection">
+          <div class="buttonWrapper">
+            <div class="nukeButton">
+              <a style="color: #ff0066"></a>
+            </div>
+            <div class="nukeButton1"></div>
+          </div>
+        </div>
+        <p id="nukeDescription">
+          The author and all commentors will be added to your user block list.
+        </p>
+      </div>
     </div>
+
     <!-- Users -->
-    <div>
-      <div class="toggle">
+    <div class="draggableSection" data-section="users">
+      <div class="sectionHeader">
+        <span class="dragHandle">&#9776;</span>
         <h2>Blocked Users</h2>
         <label class="switch">
           <input type="checkbox" id="blockUsers" checked />
           <span class="slider round"></span>
         </label>
       </div>
-      <textarea
-        class="inputList"
-        id="userList"
-        placeholder="Enter each user on a new line"
-      ></textarea>
+      <div class="sectionContent">
+        <textarea
+          class="inputList"
+          id="userList"
+          placeholder="Enter each user on a new line"
+        ></textarea>
+      </div>
     </div>
+
     <!-- Keywords -->
-    <div>
-      <div class="toggle">
+    <div class="draggableSection" data-section="keywords">
+      <div class="sectionHeader">
+        <span class="dragHandle">&#9776;</span>
         <h2>Blocked Keywords</h2>
         <label class="switch">
           <input type="checkbox" id="blockKeywords" checked />
           <span class="slider round"></span>
         </label>
       </div>
-      <textarea
-        class="inputList"
-        id="keywordList"
-        placeholder="Enter each keyword on a new line"
-      ></textarea>
+      <div class="sectionContent">
+        <textarea
+          class="inputList"
+          id="keywordList"
+          placeholder="Enter each keyword on a new line"
+        ></textarea>
+      </div>
     </div>
+
     <!-- Subreddits -->
-    <div>
-      <div class="toggle">
+    <div class="draggableSection" data-section="subreddits">
+      <div class="sectionHeader">
+        <span class="dragHandle">&#9776;</span>
         <h2>Blocked Subreddits</h2>
         <label class="switch">
           <input type="checkbox" id="blockSubreddits" checked />
           <span class="slider round"></span>
         </label>
       </div>
-      <textarea
-        class="inputList"
-        id="subredditList"
-        placeholder="Enter each subreddit on a new line"
-      ></textarea>
+      <div class="sectionContent">
+        <textarea
+          class="inputList"
+          id="subredditList"
+          placeholder="Enter each subreddit on a new line"
+        ></textarea>
+      </div>
     </div>
+
     <!-- Domains -->
-    <div>
-      <div class="toggle">
+    <div class="draggableSection" data-section="domains">
+      <div class="sectionHeader">
+        <span class="dragHandle">&#9776;</span>
         <h2>Blocked News Domains</h2>
         <label class="switch">
           <input type="checkbox" id="blockDomains" checked />
           <span class="slider round"></span>
         </label>
       </div>
-      <textarea
-        class="inputList"
-        id="domainList"
-        placeholder="Enter each domain on a new line"
-      ></textarea>
+      <div class="sectionContent">
+        <textarea
+          class="inputList"
+          id="domainList"
+          placeholder="Enter each domain on a new line"
+        ></textarea>
+      </div>
     </div>
+
+    <!-- Drop zone indicator -->
+    <div class="drop-zone"></div>
+
     <!-- Logging Preferences -->
     <div class="end">
       <div class="smallToggle">

--- a/popup.js
+++ b/popup.js
@@ -275,3 +275,208 @@ document.addEventListener("DOMContentLoaded", function () {
 
 // Loads saved data back into input
 document.addEventListener("DOMContentLoaded", loadData);
+
+// Export all blocks as JSONL
+function exportData() {
+  const users = document.getElementById("userList").value
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const keywords = document.getElementById("keywordList").value
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const subreddits = document.getElementById("subredditList").value
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const domains = document.getElementById("domainList").value
+    .split("\n")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  // Sort by category alphabetically (blockedDomains, blockedKeywords, blockedSubreddits, blockedUsers)
+  const categories = [
+    { key: "blockedDomains", label: "Blocked Domains", items: domains },
+    { key: "blockedKeywords", label: "Blocked Keywords", items: keywords },
+    { key: "blockedSubreddits", label: "Blocked Subreddits", items: subreddits },
+    { key: "blockedUsers", label: "Blocked Users", items: users },
+  ];
+
+  const lines = [];
+  categories.forEach(({ key, label, items }) => {
+    if (items.length > 0) {
+      lines.push(JSON.stringify({ category: key, label: label, items: items }));
+    }
+  });
+
+  // Also export preferences (block toggles only)
+  lines.unshift(
+    JSON.stringify({
+      category: "preferences",
+      blockUsers: document.getElementById("blockUsers").checked,
+      blockKeywords: document.getElementById("blockKeywords").checked,
+      blockSubreddits: document.getElementById("blockSubreddits").checked,
+      blockDomains: document.getElementById("blockDomains").checked,
+    })
+  );
+
+  const content = lines.join("\n") + "\n";
+  const blob = new Blob([content], { type: "application/jsonl" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `reddit-filters-export-${new Date().toISOString().slice(0,10)}.jsonl`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+// Import from JSONL file with confirmation and sanity checks
+function importData(file) {
+  const reader = new FileReader();
+  reader.onload = function (e) {
+    try {
+      const text = e.target.result;
+      const lines = text.split("\n").filter((l) => l.trim());
+
+      if (lines.length === 0) {
+        alert("Import failed: file is empty or corrupted");
+        return;
+      }
+
+      // Validate each line is valid JSON and belongs to this extension
+      const data = {
+        hiddenUsers: [],
+        hiddenKeywords: [],
+        hiddenSubreddits: [],
+        hiddenDomains: [],
+        blockUsers: null,
+        blockKeywords: null,
+        blockSubreddits: null,
+        blockDomains: null,
+      };
+
+      const validCategories = new Set([
+        "blockedUsers",
+        "blockedKeywords",
+        "blockedSubreddits",
+        "blockedDomains",
+        "preferences",
+      ]);
+
+      const keyMap = {
+        blockedUsers: "hiddenUsers",
+        blockedKeywords: "hiddenKeywords",
+        blockedSubreddits: "hiddenSubreddits",
+        blockedDomains: "hiddenDomains",
+      };
+
+      let parsedCount = 0;
+      let failed = false;
+      lines.forEach((line) => {
+        if (failed) return;
+        try {
+          const parsed = JSON.parse(line);
+          if (!parsed || typeof parsed.category !== "string") return;
+
+          if (!validCategories.has(parsed.category)) {
+            alert(
+              "Import failed: unrecognized category '" +
+                parsed.category +
+                "' — file may not be from this extension"
+            );
+            failed = true;
+            return;
+          }
+
+          parsedCount++;
+
+          if (parsed.category === "preferences") {
+            if (parsed.blockUsers !== undefined) data.blockUsers = parsed.blockUsers;
+            if (parsed.blockKeywords !== undefined) data.blockKeywords = parsed.blockKeywords;
+            if (parsed.blockSubreddits !== undefined) data.blockSubreddits = parsed.blockSubreddits;
+            if (parsed.blockDomains !== undefined) data.blockDomains = parsed.blockDomains;
+          } else if (parsed.items && Array.isArray(parsed.items)) {
+            const mapped = keyMap[parsed.category];
+            if (mapped && parsed.items.every((item) => typeof item === "string")) {
+              data[mapped] = parsed.items;
+            }
+          }
+        } catch {
+          alert("Import failed: line contains invalid JSON — file may be corrupted");
+          failed = true;
+          return;
+        }
+      });
+
+      if (failed) return;
+
+      if (parsedCount === 0) {
+        alert("Import failed: no valid data found in file");
+        return;
+      }
+
+      // Overwrite current settings
+      document.getElementById("userList").value = data.hiddenUsers.join("\n");
+      document.getElementById("keywordList").value = data.hiddenKeywords.join("\n");
+      document.getElementById("subredditList").value = data.hiddenSubreddits.join("\n");
+      document.getElementById("domainList").value = data.hiddenDomains.join("\n");
+
+      if (data.blockUsers !== null) {
+        document.getElementById("blockUsers").checked = data.blockUsers;
+      }
+      if (data.blockKeywords !== null) {
+        document.getElementById("blockKeywords").checked = data.blockKeywords;
+      }
+      if (data.blockSubreddits !== null) {
+        document.getElementById("blockSubreddits").checked = data.blockSubreddits;
+      }
+      if (data.blockDomains !== null) {
+        document.getElementById("blockDomains").checked = data.blockDomains;
+      }
+
+      // Save to storage
+      saveData();
+
+      // Show success message
+      const successEl = document.getElementById("importSuccess");
+      if (successEl) {
+        successEl.classList.remove("visible");
+        void successEl.getBoundingClientRect();
+        successEl.style.display = "block";
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            successEl.classList.add("visible");
+          });
+        });
+        setTimeout(() => {
+          successEl.classList.remove("visible");
+          setTimeout(() => {
+            successEl.style.display = "none";
+          }, 300);
+        }, 30000);
+      }
+    } catch (err) {
+      alert("Failed to parse JSONL file: " + err.message);
+    }
+  };
+  reader.readAsText(file);
+}
+
+// Warn before opening file picker
+function triggerImport() {
+  if (!confirm("Importing will replace your current block lists. Do you wish to continue?")) {
+    return;
+  }
+  document.getElementById("importFileInput").click();
+}
+
+// Set up import/export button listeners
+document.getElementById("exportBtn").addEventListener("click", exportData);
+document.getElementById("importBtn").addEventListener("click", triggerImport);
+document.getElementById("importFileInput").addEventListener("change", function (e) {
+  if (e.target.files.length > 0) {
+    importData(e.target.files[0]);
+    e.target.value = ""; // Reset so same file can be re-imported
+  }
+});

--- a/popup.js
+++ b/popup.js
@@ -25,6 +25,7 @@ function saveData() {
   const blockKeywords = document.getElementById("blockKeywords").checked;
   const blockSubreddits = document.getElementById("blockSubreddits").checked;
   const blockDomains = document.getElementById("blockDomains").checked;
+  const nukeConfirm = document.getElementById("nukeConfirm").checked;
 
   // Save the data using the Chrome storage API
   chrome.storage.local.set({
@@ -38,6 +39,7 @@ function saveData() {
     blockKeywords: blockKeywords,
     blockSubreddits: blockSubreddits,
     blockDomains: blockDomains,
+    nukeConfirm: nukeConfirm,
   });
 }
 
@@ -55,6 +57,7 @@ function loadData() {
       "blockKeywords",
       "blockSubreddits",
       "blockDomains",
+      "nukeConfirm",
     ],
     function (result) {
       if (result.hiddenUsers) {
@@ -97,6 +100,9 @@ function loadData() {
       }
       if (result.blockDomains !== undefined) {
         document.getElementById("blockDomains").checked = result.blockDomains;
+      }
+      if (result.nukeConfirm !== undefined) {
+        document.getElementById("nukeConfirm").checked = result.nukeConfirm;
       }
 
       // Load saved section order
@@ -266,6 +272,10 @@ document.addEventListener("DOMContentLoaded", function () {
 
   if (button) {
     button.addEventListener("click", function () {
+      const requireConfirm = document.getElementById("nukeConfirm").checked;
+      if (requireConfirm && !confirm("Are you sure? This will add the author and commentors to your block list.")) {
+        return;
+      }
       nuke();
     });
   }
@@ -318,6 +328,7 @@ function exportData() {
       blockKeywords: document.getElementById("blockKeywords").checked,
       blockSubreddits: document.getElementById("blockSubreddits").checked,
       blockDomains: document.getElementById("blockDomains").checked,
+      nukeConfirm: document.getElementById("nukeConfirm").checked,
     })
   );
 
@@ -354,6 +365,7 @@ function importData(file) {
         blockKeywords: null,
         blockSubreddits: null,
         blockDomains: null,
+        nukeConfirm: null,
       };
 
       const validCategories = new Set([
@@ -396,6 +408,7 @@ function importData(file) {
             if (parsed.blockKeywords !== undefined) data.blockKeywords = parsed.blockKeywords;
             if (parsed.blockSubreddits !== undefined) data.blockSubreddits = parsed.blockSubreddits;
             if (parsed.blockDomains !== undefined) data.blockDomains = parsed.blockDomains;
+            if (parsed.nukeConfirm !== undefined) data.nukeConfirm = parsed.nukeConfirm;
           } else if (parsed.items && Array.isArray(parsed.items)) {
             const mapped = keyMap[parsed.category];
             if (mapped && parsed.items.every((item) => typeof item === "string")) {
@@ -431,12 +444,12 @@ function importData(file) {
       if (data.blockSubreddits !== null) {
         document.getElementById("blockSubreddits").checked = data.blockSubreddits;
       }
-      if (data.blockDomains !== null) {
+    if (data.blockDomains !== null) {
         document.getElementById("blockDomains").checked = data.blockDomains;
       }
-
-      // Save to storage
-      saveData();
+      if (data.nukeConfirm !== null) {
+        document.getElementById("nukeConfirm").checked = data.nukeConfirm;
+      }
 
       // Show success message
       const successEl = document.getElementById("importSuccess");

--- a/popup.js
+++ b/popup.js
@@ -14,7 +14,7 @@ function saveData() {
     .split("\n")
     .map((item) => item.trim());
 
-  // Fetch subreddits from input
+  // Fetch domains from input
   const domainsString = document.getElementById("domainList").value;
   const domainsArray = domainsString.split("\n").map((item) => item.trim());
 
@@ -98,8 +98,39 @@ function loadData() {
       if (result.blockDomains !== undefined) {
         document.getElementById("blockDomains").checked = result.blockDomains;
       }
+
+      // Load saved section order
+      loadSectionOrder();
     }
   );
+}
+
+function saveSectionOrder() {
+  const sections = document.querySelectorAll(".draggableSection");
+  const order = Array.from(sections).map((s) => s.dataset.section);
+  chrome.storage.local.set({ sectionOrder: order });
+}
+
+function loadSectionOrder() {
+  chrome.storage.local.get(["sectionOrder"], function (result) {
+    if (!result.sectionOrder || result.sectionOrder.length === 0) return;
+
+    const sections = document.querySelectorAll(".draggableSection");
+    const sectionMap = {};
+    sections.forEach((s) => {
+      sectionMap[s.dataset.section] = s;
+    });
+
+    const body = document.body;
+    const dropZone = document.querySelector(".drop-zone");
+    const endDiv = document.querySelector(".end");
+
+    result.sectionOrder.forEach((key) => {
+      if (sectionMap[key]) {
+        body.insertBefore(sectionMap[key], dropZone);
+      }
+    });
+  });
 }
 
 function nuke() {
@@ -141,14 +172,95 @@ document.getElementById("userList").addEventListener("input", saveData);
 document.getElementById("keywordList").addEventListener("input", saveData);
 document.getElementById("subredditList").addEventListener("input", saveData);
 document.getElementById("domainList").addEventListener("input", saveData);
-document.getElementById("loggingEnabled").addEventListener("change", saveData);
-document.getElementById("expandImages").addEventListener("change", saveData);
-document.getElementById("blockUsers").addEventListener("change", saveData);
-document.getElementById("blockKeywords").addEventListener("change", saveData);
-document.getElementById("blockSubreddits").addEventListener("change", saveData);
-document.getElementById("blockDomains").addEventListener("change", saveData);
 
-// Loads nuke button listener
+// Drag and drop logic
+let draggedSection = null;
+const dropZone = document.querySelector(".drop-zone");
+let lastReorderKey = ""; // Guard against unnecessary DOM mutations
+
+function onDragStart(e) {
+  draggedSection = this.closest(".draggableSection");
+  draggedSection.classList.add("dragging");
+  e.dataTransfer.effectAllowed = "move";
+}
+
+function onDragEnd() {
+  if (draggedSection) {
+    draggedSection.classList.remove("dragging");
+  }
+  draggedSection = null;
+  lastReorderKey = "";
+}
+
+// Set up drag and drop on section headers
+function setupDragDrop() {
+  const headers = document.querySelectorAll(".sectionHeader");
+  headers.forEach((header) => {
+    header.setAttribute("draggable", "true");
+    header.addEventListener("dragstart", onDragStart);
+    header.addEventListener("dragend", onDragEnd);
+  });
+
+  // Per-section dragover — triggers reorder when cursor enters each section's area during drag
+  const allSections = document.querySelectorAll(".draggableSection");
+  allSections.forEach((section) => {
+    section.addEventListener("dragover", function (e) {
+      e.preventDefault();
+      if (!draggedSection || draggedSection === this) return;
+
+      // Find first non-dragged section whose midpoint cursor is above
+      const otherSections = Array.from(document.querySelectorAll(".draggableSection"))
+        .filter((s) => s !== draggedSection);
+
+      let insertBeforeIdx = -1;
+      for (let i = 0; i < otherSections.length; i++) {
+        const rect = otherSections[i].getBoundingClientRect();
+        const midY = rect.top + rect.height / 2;
+        if (e.clientY <= midY) {
+          insertBeforeIdx = i;
+          break;
+        }
+      }
+
+      let targetNode;
+      if (insertBeforeIdx === -1) {
+        const endDiv = document.querySelector(".end");
+        if (endDiv && draggedSection.nextElementSibling !== endDiv) {
+          draggedSection.parentNode.insertBefore(draggedSection, endDiv);
+        }
+      } else {
+        targetNode = otherSections[insertBeforeIdx];
+        if (draggedSection.nextElementSibling !== targetNode) {
+          draggedSection.parentNode.insertBefore(draggedSection, targetNode);
+        }
+      }
+    });
+
+    section.addEventListener("drop", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+      saveSectionOrder();
+    });
+  });
+  if (dropZone) {
+    dropZone.addEventListener("dragover", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+    });
+    dropZone.addEventListener("drop", function (e) {
+      e.preventDefault();
+      e.stopPropagation();
+
+      const endDiv = document.querySelector(".end");
+      if (endDiv && draggedSection !== endDiv.previousSibling) {
+        document.body.insertBefore(draggedSection, endDiv);
+      }
+      saveSectionOrder();
+    });
+  }
+}
+
+// Set up nuke button listener
 document.addEventListener("DOMContentLoaded", function () {
   var button = document.querySelector(".nukeButton");
 
@@ -157,6 +269,8 @@ document.addEventListener("DOMContentLoaded", function () {
       nuke();
     });
   }
+
+  setupDragDrop();
 });
 
 // Loads saved data back into input

--- a/popup.js
+++ b/popup.js
@@ -169,7 +169,9 @@ function nuke() {
             combinedUsersArray.join("\n");
         }
       );
-    } catch (err) {}
+    } catch (err) {
+      console.error("Nuke failed:", err);
+    }
   });
 }
 
@@ -444,7 +446,7 @@ function importData(file) {
       if (data.blockSubreddits !== null) {
         document.getElementById("blockSubreddits").checked = data.blockSubreddits;
       }
-    if (data.blockDomains !== null) {
+      if (data.blockDomains !== null) {
         document.getElementById("blockDomains").checked = data.blockDomains;
       }
       if (data.nukeConfirm !== null) {


### PR DESCRIPTION
## Summary

Managing blocklists at scale was friction-heavy: no backup or cross-browser migration, no in-feed blocking without navigating away, partial keyword matches causing unintended post hiding, and no way to prioritise the blocklists you use most. The Nuke action also lacked any guard against accidental triggers.

This PR addresses those pain points: import/export for backup and migration, one-click in-feed subreddit blocking, word-boundary keyword matching, reorderable sections to keep your most-used blocklists within reach, a stats page showing which rules trigger most frequently, and a bypass option to temporarily view a blocked subreddit's page without removing it from the blocklist.

## Features

### Blocklist Import & Export
- Users can now export their current blocklists (keywords, domains, subreddits) to a JSON file
- Imported blocklists are merged into existing configuration
- Enables backup, sharing, and migration of filter rules across browsers/devices

### Reorderable Sections
- Blocking categories (Keywords, Subreddits, Websites) can now be reordered by dragging the hamburger handle beside each section header
- Prioritise the lists you use most by moving them to the top

### Subreddit Blocking from Feed
- New "Block r/[sub]" button appears beside the subreddit name on feed posts
- One-click blocking without navigating to subreddit settings
- Blocked subreddits are immediately added to the blocklist

### Stats Tracking & Blocked Subreddit Banner
- Statistics tracking for blocked content (posts/comments hidden counts)
- Visual banner displayed when viewing pages from blocked subreddits
- Stats page surfaces the most frequently triggered keywords, giving insight into which rules are doing the most work
- Provides feedback on filter effectiveness

### Bypass/Unblock for Blocked Subreddits
- Ability to temporarily unblock a previously blocked subreddit page
- Removes the "blocked" state and restores content visibility
- Filter sections search removed in favor of streamlined UI

### Nuke Confirm Toggle
- Optional confirmation dialog before triggering "Nuke" (full feed refresh/clear)
- Toggleable in settings to suit user preference

## Breaking Changes

None. All changes are additive or modify existing behavior without altering stored data schemas or extension APIs.

## Testing Steps for Reviewers

1. **Import/Export** — Open the popup UI, click "Export Blocklist", verify a `.json` file downloads containing `keywords`, `domains`, and `subreddits` arrays. Then edit the JSON (add a dummy subreddit), return to the popup, click "Import Blocklist", select the file, confirm merged entries appear in the existing lists.

2. **Subreddit Blocking** — Navigate to any Reddit feed page. Locate a post with a subreddit name visible. Click the new "Block r/[sub]" button beside it (Looks like an 'X'). Verify the subreddit appears in the blocked subreddits list in the popup and that subsequent feed renders hide posts from that subreddit.

3. **Keyword Word-Boundary Matching** — Add a keyword like `"cat"` to your keyword blocklist. Navigate to a feed containing posts with titles like "category" or "catalog". Verify these are NOT hidden (word-boundary matching prevents partial matches). Then verify a post titled exactly "cat food" IS hidden.

4. **Nuke Confirm Toggle** — Enable the nuke confirm toggle in settings. Click the "Nuke" button on a feed page. Verify a confirmation dialog appears. Dismiss it and verify the feed is untouched. Re-enable Nuke (no confirm) and verify it fires immediately without a prompt.

5. **Blocked Subreddit Banner & Bypass** — Block any subreddit, then navigate directly to that subreddit's page in Reddit. Verify a banner appears at the top indicating the subreddit is blocked. Click the bypass/unblock action on the banner. Verify the banner disappears and content renders normally. Confirm the subreddit is removed from the blocked list in the popup.

6. **Article Wrapper Cleanup** — Block a post using any method (keyword, domain, or subreddit). On the feed page, inspect the DOM around the hidden post area. Verify no orphaned `<article>` elements or `<hr>` separators remain visible.

## Bug Fixes

- Keyword matching now uses word-boundary regex (`\b`) to prevent partial matches (e.g., "cat" no longer matches "category")
- Nuke confirm dialog gated to thread pages only, preventing unwanted prompts on feed views
- Article wrapper (`<article>`) and orphaned `<hr>` separators hidden when posts are blocked, eliminating layout gaps
- Renamed "Blocked News Domains" → "Blocked Websites" for clarity

## Housekeeping

- Clarified UI labels to distinguish between blocking buttons (post vs. subreddit)
- Removed dead code and fixed minor CSS/style issues